### PR TITLE
Fix test mode vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ config :media,
   aws_access_key_id: "AKIAV3V******",
   aws_secret_key: "VoF7GeKJh6A2On******",
   youtube_api_key: "AIzaSyBwQKaa*******",
-  test_mode: "real"
+  test_mode: "real",
+  test_mode_database: "real"
 ```
 ``active_database``: the database your project is using accepted values are: "mongoDB" or "postgreSQL"
 ``repo``: The mongodb application name or the repo module in case it's a postgreSQL based project i.e ``YourApp.Repo``.
@@ -126,6 +127,8 @@ config :media,
 `aws_role_name`: In AWS, you can create roles (`IAM` roles) that has certain permission. This role will be assumed in order to authenticate the access to private files
 `aws_iam_id`: The IAM user ID.
 `youtube_api_key`: The youtube api key to fetch videos details.
+`test_mode`: Used to return dummy responses when value is not `real`
+`test_mode_database`: Used to create media database and use Media's Mongo when value is not `real`
   In case your project relies on a ``MongoDB``, in your  ``application.ex`` file add this tuple to the children list inside the ``start`` function:
 
 *NOTE: for AWS and Youtube credentials check the S3Manager Module*

--- a/config/test.exs
+++ b/config/test.exs
@@ -38,7 +38,8 @@ config :media,
   aws_bucket_name: "eweevtestbucketprivate",
   aws_role_name: "FullBucketAccess",
   aws_iam_id: "403016165142",
-  test_mode: "fake"
+  test_mode: "fake",
+  test_mode_database: "fake"
 
 # content_schema: Sections.Section.Type
 

--- a/lib/media/application.ex
+++ b/lib/media/application.ex
@@ -20,7 +20,7 @@ defmodule Media.Application do
     ]
 
     children =
-      if Helpers.test_mode?() do
+      if Helpers.test_mode?(:database) do
         databases = [
           {Mongo,
            [

--- a/lib/media/helper_modules/helpers.ex
+++ b/lib/media/helper_modules/helpers.ex
@@ -760,7 +760,7 @@ defmodule Media.Helpers do
 
   ## gets youtube details on the video using the api key and video id
   def youtube_video_details(video_id) do
-    if test_mode?() do
+    if test_mode?(:response) do
       ## For testing purposes
       %{"items" => [%{"contentDetails" => %{"duration" => "PT03M30S"}}]}
     else
@@ -916,9 +916,16 @@ defmodule Media.Helpers do
   This functions checks the environment we are in and the test mode.
   If the test mode is real or the env is not :test it returns true
   false otherwise
+
+  Sometimes we want to split the test mode between the responses and the database
+  Because we need to use an existing project's database, and dummy responses from media
   """
-  def test_mode? do
+  def test_mode?(:response) do
     env(:test_mode, "real") != "real"
+  end
+
+  def test_mode?(:database) do
+    env(:test_mode_database, "real") != "real"
   end
 
   def validate_platforms(%Ecto.Changeset{valid?: false} = changeset, _), do: changeset

--- a/lib/media/helper_modules/s3_manager.ex
+++ b/lib/media/helper_modules/s3_manager.ex
@@ -105,7 +105,7 @@ defmodule Media.S3Manager do
 
   @doc false
   def upload(path, filename) do
-    if Helpers.test_mode?() do
+    if Helpers.test_mode?(:response) do
       {:ok,
        %{
          id: "fake_file_id",
@@ -198,7 +198,7 @@ defmodule Media.S3Manager do
 
   @doc false
   def get_temporary_aws_credentials(profile_id) do
-    if Helpers.test_mode?() do
+    if Helpers.test_mode?(:response) do
       resp =
         STS.assume_role(
           "arn:aws:iam::" <>
@@ -257,7 +257,7 @@ defmodule Media.S3Manager do
   end
 
   defp change_privacy(object_key, acl_permission) do
-    if Helpers.test_mode?() do
+    if Helpers.test_mode?(:response) do
       {:ok, :done}
     else
       {:ok,

--- a/priv/repo/migrations/00000000000000_content_for_tests.exs
+++ b/priv/repo/migrations/00000000000000_content_for_tests.exs
@@ -1,7 +1,7 @@
 defmodule Media.Repo.Migrations.ContentForTests do
   use Ecto.Migration
 
-  if Media.Helpers.test_mode?() do
+  if Media.Helpers.test_mode?(:database) do
     def change do
       create table(:content) do
         add(:title, :string)


### PR DESCRIPTION
- Re-add the separate database environment variable

This is because in almost all use cases (implementation in other projects), we would like Media to return dummy responses in the automated tests, but use the project's database.